### PR TITLE
feat: 支持标签阈值覆盖配置

### DIFF
--- a/src/pages/alert/rule/create.jsx
+++ b/src/pages/alert/rule/create.jsx
@@ -50,6 +50,8 @@ import {SearchViewMetrics} from "../preview/searchViewMetrics.tsx";
 import {Breadcrumb} from "../../../components/Breadcrumb"
 
 const format = 'HH:mm';
+const THRESHOLD_MODE_GLOBAL = 'global';
+const THRESHOLD_MODE_NODE_OVERRIDE = 'node_override';
 const MyFormItemContext = React.createContext([])
 const { Option } = Select;
 
@@ -75,6 +77,7 @@ export const AlertRule = ({ type }) => {
     const searchParams = new URLSearchParams(window.location.search);
     const { appState } = useAppContext();
     const [form] = Form.useForm()
+    const thresholdMode = Form.useWatch(['prometheusConfig', 'thresholdMode'], form);
     const { id,ruleId } = useParams()
     const [selectedRow,setSelectedRow] = useState({})
     const [enabled, setEnabled] = useState(true) // 设置初始状态为 true
@@ -211,7 +214,11 @@ export const AlertRule = ({ type }) => {
             if (type !== "edit" && searchParams.get("isClone") !== "1") {
                 // 设置执行频率默认值为5
                 form.setFieldsValue({
-                    evalInterval: 5
+                    evalInterval: 5,
+                    prometheusConfig: {
+                        thresholdMode: THRESHOLD_MODE_GLOBAL,
+                        thresholdOverrides: [],
+                    }
                 });
             }
         }
@@ -252,6 +259,8 @@ export const AlertRule = ({ type }) => {
                 annotations: selectedRow?.prometheusConfig?.annotations,
                 forDuration: selectedRow?.prometheusConfig?.forDuration,
                 rules: selectedRow?.prometheusConfig?.rules,
+                thresholdMode: selectedRow?.prometheusConfig?.thresholdMode || THRESHOLD_MODE_GLOBAL,
+                thresholdOverrides: selectedRow?.prometheusConfig?.thresholdOverrides || [],
                 callbakPromQLs: selectedRow?.prometheusConfig?.callbakPromQLs || [],
             },
             alicloudSLSConfig: {
@@ -524,6 +533,7 @@ export const AlertRule = ({ type }) => {
             ...values,
             externalLabels: formattedLabels,
             evalInterval: Number(values.evalInterval),
+            prometheusConfig: normalizeThresholdOverrides(values.prometheusConfig),
             elasticSearchConfig: newEsConfig,
             effectiveTime: {
                 week: week,
@@ -625,6 +635,41 @@ export const AlertRule = ({ type }) => {
         const updatedExprRule = [...exprRule]
         updatedExprRule.splice(index, 1)
         setExprRule(updatedExprRule)
+    }
+
+    const getDefaultOverrideSeverity = () => {
+        const rules = form.getFieldValue(['prometheusConfig', 'rules']) || exprRule || []
+        return rules?.[0]?.severity || 'P0'
+    }
+
+    const getDefaultOverrideDuration = () => {
+        const rules = form.getFieldValue(['prometheusConfig', 'rules']) || exprRule || []
+        return rules?.[0]?.forDuration || 300
+    }
+
+    const normalizeThresholdOverrides = (prometheusConfig = {}) => {
+        if (prometheusConfig.thresholdMode !== THRESHOLD_MODE_NODE_OVERRIDE) {
+            return {
+                ...prometheusConfig,
+                thresholdMode: THRESHOLD_MODE_GLOBAL,
+                thresholdOverrides: [],
+            }
+        }
+
+        const thresholdOverrides = (prometheusConfig.thresholdOverrides || [])
+            .map((item) => ({
+                matchLabels: Object.fromEntries(
+                    Object.entries(item?.matchLabels || {}).filter((entry) => entry[1] !== undefined && entry[1] !== '')
+                ),
+                rules: (item?.rules || []).filter((rule) => rule?.severity && rule?.expr),
+            }))
+            .filter((item) => Object.keys(item.matchLabels).length > 0 && item.rules.length > 0)
+
+        return {
+            ...prometheusConfig,
+            thresholdMode: thresholdOverrides.length > 0 ? THRESHOLD_MODE_NODE_OVERRIDE : THRESHOLD_MODE_GLOBAL,
+            thresholdOverrides,
+        }
     }
 
     const handleChange = (value) => {
@@ -1173,6 +1218,120 @@ export const AlertRule = ({ type }) => {
                                         <Button icon={<PlusOutlined/>} type="dashed" block onClick={addExprRule} disabled={exprRule?.length === 3}>
                                             添加规则条件
                                         </Button>
+                                    </div>
+
+                                    <div style={{ marginTop: '30px' }}>
+                                        <MyFormItem name="thresholdMode" hidden>
+                                            <Input />
+                                        </MyFormItem>
+
+                                        <div style={{ display: 'flex', alignItems: 'center', gap: '12px', marginBottom: '12px' }}>
+                                            <span style={{ fontWeight: 500 }}>节点阈值覆盖</span>
+                                            <Switch
+                                                checked={thresholdMode === THRESHOLD_MODE_NODE_OVERRIDE}
+                                                onChange={(checked) => {
+                                                    form.setFieldsValue({
+                                                        prometheusConfig: {
+                                                            thresholdMode: checked ? THRESHOLD_MODE_NODE_OVERRIDE : THRESHOLD_MODE_GLOBAL,
+                                                            thresholdOverrides: checked ? form.getFieldValue(['prometheusConfig', 'thresholdOverrides']) || [] : [],
+                                                        },
+                                                    })
+                                                }}
+                                            />
+                                        </div>
+
+                                        {thresholdMode === THRESHOLD_MODE_NODE_OVERRIDE && (
+                                            <Form.List name={['prometheusConfig', 'thresholdOverrides']}>
+                                                {(fields, { add, remove }) => (
+                                                    <>
+                                                        {fields.map(({ key, name, ...restField }) => (
+                                                            <div
+                                                                key={key}
+                                                                style={{
+                                                                    display: 'grid',
+                                                                    gridTemplateColumns: 'minmax(220px, 1.5fr) 120px minmax(180px, 1fr) 180px 48px',
+                                                                    gap: '10px',
+                                                                    alignItems: 'start',
+                                                                    marginBottom: '8px',
+                                                                }}
+                                                            >
+                                                                <Form.Item
+                                                                    {...restField}
+                                                                    name={[name, 'matchLabels', 'instance']}
+                                                                    rules={[{ required: true, message: '请输入节点 instance' }]}
+                                                                >
+                                                                    <Input placeholder="节点 instance，例如 10.0.0.1:9100" />
+                                                                </Form.Item>
+
+                                                                <Form.Item
+                                                                    {...restField}
+                                                                    name={[name, 'rules', 0, 'severity']}
+                                                                    rules={[{ required: true, message: '请选择等级' }]}
+                                                                >
+                                                                    <Select placeholder="P0">
+                                                                        <Option value="P0">P0</Option>
+                                                                        <Option value="P1">P1</Option>
+                                                                        <Option value="P2">P2</Option>
+                                                                    </Select>
+                                                                </Form.Item>
+
+                                                                <Form.Item
+                                                                    {...restField}
+                                                                    name={[name, 'rules', 0, 'expr']}
+                                                                    rules={[
+                                                                        { required: true, message: '请输入告警条件' },
+                                                                        {
+                                                                            validator: (_, value) => {
+                                                                                if (!value || validateExpr(value)) {
+                                                                                    return Promise.resolve()
+                                                                                }
+                                                                                return Promise.reject(new Error('请输入有效的告警条件，例如：> 98'))
+                                                                            },
+                                                                        },
+                                                                    ]}
+                                                                >
+                                                                    <Input placeholder="例如：> 98" />
+                                                                </Form.Item>
+
+                                                                <Form.Item
+                                                                    {...restField}
+                                                                    name={[name, 'rules', 0, 'forDuration']}
+                                                                    rules={[{ required: true, message: '请输入持续时间' }]}
+                                                                >
+                                                                    <InputNumber
+                                                                        addonBefore="持续"
+                                                                        addonAfter="秒"
+                                                                        placeholder="300"
+                                                                        min={0}
+                                                                        style={{ width: '100%' }}
+                                                                    />
+                                                                </Form.Item>
+
+                                                                <Button onClick={() => remove(name)}>
+                                                                    -
+                                                                </Button>
+                                                            </div>
+                                                        ))}
+
+                                                        <Button
+                                                            type="dashed"
+                                                            block
+                                                            icon={<PlusOutlined />}
+                                                            onClick={() => add({
+                                                                matchLabels: { instance: '' },
+                                                                rules: [{
+                                                                    severity: getDefaultOverrideSeverity(),
+                                                                    expr: '',
+                                                                    forDuration: getDefaultOverrideDuration(),
+                                                                }],
+                                                            })}
+                                                        >
+                                                            添加节点阈值
+                                                        </Button>
+                                                    </>
+                                                )}
+                                            </Form.List>
+                                        )}
                                     </div>
 
                                     <div style={{ marginTop: '30px' }}>

--- a/src/pages/alert/rule/create.jsx
+++ b/src/pages/alert/rule/create.jsx
@@ -10,13 +10,13 @@ import {
     InputNumber,
     Card,
     TimePicker,
-    Typography, Modal, message, Checkbox
+    Typography, Modal, message, Checkbox, AutoComplete
 } from 'antd'
 import React, { useState, useEffect } from 'react'
 import {MinusCircleOutlined, PlusOutlined, RedoOutlined} from '@ant-design/icons'
 import {createRule, searchRuleInfo, updateRule} from '../../../api/rule'
 import {getDatasource, getDatasourceList} from '../../../api/datasource'
-import {getJaegerService} from '../../../api/other'
+import {getJaegerService, queryPromMetrics} from '../../../api/other'
 import {useParams} from 'react-router-dom'
 import dayjs from 'dayjs';
 import './index.css'
@@ -149,6 +149,8 @@ export const AlertRule = ({ type }) => {
     const [filterCondition,setFilterCondition] = useState('') // 匹配关系
     const [queryWildcard,setQueryWildcard] = useState(0) // 匹配模式
     const [metricAddress,setMetricAddress] = useState("")
+    const [nodeInstanceOptions, setNodeInstanceOptions] = useState([])
+    const [loadingNodeInstances, setLoadingNodeInstances] = useState(false)
     const [viewLogsModalKey, setViewLogsModalKey] = useState(0);
     const [viewMetricsModalKey, setViewMetricsModalKey] = useState(0);
     const [openSearchContentModal, setOpenSearchContentModal] = useState(false)
@@ -887,6 +889,55 @@ export const AlertRule = ({ type }) => {
         setOpenMetricQueryModel(true)
     };
 
+    const handleQueryNodeInstances = async () => {
+        const currentPromQL = handleGetPromQL()
+        if (!selectedItems || selectedItems.length === 0) {
+            message.error("请先选择数据源")
+            return
+        }
+        if (!currentPromQL) {
+            message.error("请先填写 PromQL")
+            return
+        }
+
+        try {
+            setLoadingNodeInstances(true)
+            const res = await queryPromMetrics({
+                datasourceIds: selectedItems.join(","),
+                query: currentPromQL,
+            })
+
+            if (res.code !== 200) {
+                message.error(res.msg || "查询节点失败")
+                return
+            }
+
+            const instances = Array.from(new Set(
+                (res.data || [])
+                    .flatMap((item) => item?.data?.result || [])
+                    .map((item) => item?.metric?.instance)
+                    .filter(Boolean)
+            )).sort()
+
+            setNodeInstanceOptions(instances.map((instance) => ({
+                label: instance,
+                value: instance,
+            })))
+
+            if (instances.length === 0) {
+                message.warning("当前 PromQL 未返回 instance 标签")
+                return
+            }
+
+            message.success(`已加载 ${instances.length} 个节点`)
+        } catch (error) {
+            console.error(error)
+            message.error("查询节点失败")
+        } finally {
+            setLoadingNodeInstances(false)
+        }
+    }
+
     const handleGetKubernetesEventTypes = async() =>{
         try{
             const res = await getKubernetesResourceList()
@@ -1238,6 +1289,15 @@ export const AlertRule = ({ type }) => {
                                                     })
                                                 }}
                                             />
+                                            {thresholdMode === THRESHOLD_MODE_NODE_OVERRIDE && (
+                                                <Button
+                                                    size="small"
+                                                    loading={loadingNodeInstances}
+                                                    onClick={handleQueryNodeInstances}
+                                                >
+                                                    查询节点
+                                                </Button>
+                                            )}
                                         </div>
 
                                         {thresholdMode === THRESHOLD_MODE_NODE_OVERRIDE && (
@@ -1260,7 +1320,13 @@ export const AlertRule = ({ type }) => {
                                                                     name={[name, 'matchLabels', 'instance']}
                                                                     rules={[{ required: true, message: '请输入节点 instance' }]}
                                                                 >
-                                                                    <Input placeholder="节点 instance，例如 10.0.0.1:9100" />
+                                                                    <AutoComplete
+                                                                        placeholder="选择或输入节点 instance"
+                                                                        options={nodeInstanceOptions}
+                                                                        filterOption={(inputValue, option) =>
+                                                                            option?.value?.toUpperCase().includes(inputValue.toUpperCase())
+                                                                        }
+                                                                    />
                                                                 </Form.Item>
 
                                                                 <Form.Item

--- a/src/pages/alert/rule/create.jsx
+++ b/src/pages/alert/rule/create.jsx
@@ -149,8 +149,9 @@ export const AlertRule = ({ type }) => {
     const [filterCondition,setFilterCondition] = useState('') // 匹配关系
     const [queryWildcard,setQueryWildcard] = useState(0) // 匹配模式
     const [metricAddress,setMetricAddress] = useState("")
-    const [nodeInstanceOptions, setNodeInstanceOptions] = useState([])
-    const [loadingNodeInstances, setLoadingNodeInstances] = useState(false)
+    const [metricLabelOptions, setMetricLabelOptions] = useState([])
+    const [metricLabelValueOptions, setMetricLabelValueOptions] = useState({})
+    const [loadingMetricLabels, setLoadingMetricLabels] = useState(false)
     const [viewLogsModalKey, setViewLogsModalKey] = useState(0);
     const [viewMetricsModalKey, setViewMetricsModalKey] = useState(0);
     const [openSearchContentModal, setOpenSearchContentModal] = useState(false)
@@ -649,6 +650,49 @@ export const AlertRule = ({ type }) => {
         return rules?.[0]?.forDuration || 300
     }
 
+    const getOverrideMatchLabelKey = (overrideIndex) => {
+        const matchLabels = form.getFieldValue(['prometheusConfig', 'thresholdOverrides', overrideIndex, 'matchLabels']) || {}
+        return Object.keys(matchLabels).find((key) => matchLabels[key] !== undefined) || ''
+    }
+
+    const updateOverrideMatchLabelKey = (overrideIndex, nextKey) => {
+        const thresholdOverrides = form.getFieldValue(['prometheusConfig', 'thresholdOverrides']) || []
+        const nextOverrides = [...thresholdOverrides]
+        const currentOverride = nextOverrides[overrideIndex] || {}
+        const currentLabels = currentOverride.matchLabels || {}
+        const currentValue = currentLabels[getOverrideMatchLabelKey(overrideIndex)] || ''
+        const nextMatchLabels = nextKey ? { [nextKey]: currentValue } : {}
+
+        nextOverrides[overrideIndex] = {
+            ...currentOverride,
+            matchLabels: nextMatchLabels,
+        }
+
+        form.setFieldsValue({
+            prometheusConfig: {
+                thresholdOverrides: nextOverrides,
+            },
+        })
+    }
+
+    const updateOverrideMatchLabelValue = (overrideIndex, labelKey, nextValue) => {
+        const thresholdOverrides = form.getFieldValue(['prometheusConfig', 'thresholdOverrides']) || []
+        const nextOverrides = [...thresholdOverrides]
+        const currentOverride = nextOverrides[overrideIndex] || {}
+        const nextMatchLabels = labelKey ? { [labelKey]: nextValue } : {}
+
+        nextOverrides[overrideIndex] = {
+            ...currentOverride,
+            matchLabels: nextMatchLabels,
+        }
+
+        form.setFieldsValue({
+            prometheusConfig: {
+                thresholdOverrides: nextOverrides,
+            },
+        })
+    }
+
     const normalizeThresholdOverrides = (prometheusConfig = {}) => {
         if (prometheusConfig.thresholdMode !== THRESHOLD_MODE_NODE_OVERRIDE) {
             return {
@@ -889,54 +933,102 @@ export const AlertRule = ({ type }) => {
         setOpenMetricQueryModel(true)
     };
 
-    const handleQueryNodeInstances = async () => {
+    const handleQueryMetricLabels = async ({ silent = false } = {}) => {
         const currentPromQL = handleGetPromQL()
         if (!selectedItems || selectedItems.length === 0) {
-            message.error("请先选择数据源")
+            if (!silent) {
+                message.error("请先选择数据源")
+            }
             return
         }
         if (!currentPromQL) {
-            message.error("请先填写 PromQL")
+            if (!silent) {
+                message.error("请先填写 PromQL")
+            }
             return
         }
 
         try {
-            setLoadingNodeInstances(true)
+            setLoadingMetricLabels(true)
             const res = await queryPromMetrics({
                 datasourceIds: selectedItems.join(","),
                 query: currentPromQL,
             })
 
             if (res.code !== 200) {
-                message.error(res.msg || "查询节点失败")
+                if (!silent) {
+                    message.error(res.msg || "查询标签失败")
+                }
                 return
             }
 
-            const instances = Array.from(new Set(
-                (res.data || [])
-                    .flatMap((item) => item?.data?.result || [])
-                    .map((item) => item?.metric?.instance)
-                    .filter(Boolean)
-            )).sort()
+            const labelValues = {}
+            ;(res.data || [])
+                .flatMap((item) => item?.data?.result || [])
+                .forEach((item) => {
+                    Object.entries(item?.metric || {}).forEach(([key, value]) => {
+                        if (!key || key === '__name__' || value === undefined || value === '') {
+                            return
+                        }
 
-            setNodeInstanceOptions(instances.map((instance) => ({
-                label: instance,
-                value: instance,
+                        if (!labelValues[key]) {
+                            labelValues[key] = new Set()
+                        }
+                        labelValues[key].add(value)
+                    })
+                })
+
+            const nextLabelValueOptions = Object.fromEntries(
+                Object.entries(labelValues).map(([key, values]) => [
+                    key,
+                    Array.from(values).sort().map((value) => ({
+                        label: value,
+                        value,
+                    })),
+                ])
+            )
+            const labelKeys = Object.keys(nextLabelValueOptions).sort()
+
+            setMetricLabelOptions(labelKeys.map((key) => ({
+                label: key,
+                value: key,
             })))
+            setMetricLabelValueOptions(nextLabelValueOptions)
 
-            if (instances.length === 0) {
-                message.warning("当前 PromQL 未返回 instance 标签")
+            if (labelKeys.length === 0) {
+                if (!silent) {
+                    message.warning("当前 PromQL 未返回可用于匹配的标签")
+                }
                 return
             }
 
-            message.success(`已加载 ${instances.length} 个节点`)
+            if (!silent) {
+                message.success(`已加载 ${labelKeys.length} 个标签`)
+            }
         } catch (error) {
             console.error(error)
-            message.error("查询节点失败")
+            if (!silent) {
+                message.error("查询标签失败")
+            }
         } finally {
-            setLoadingNodeInstances(false)
+            setLoadingMetricLabels(false)
         }
     }
+
+    useEffect(() => {
+        if (selectedType !== 0 || thresholdMode !== THRESHOLD_MODE_NODE_OVERRIDE) {
+            return
+        }
+        if (!selectedItems || selectedItems.length === 0 || !handleGetPromQL()) {
+            return
+        }
+
+        const timer = setTimeout(() => {
+            handleQueryMetricLabels({ silent: true })
+        }, 600)
+
+        return () => clearTimeout(timer)
+    }, [selectedType, thresholdMode, selectedItems, promQL])
 
     const handleGetKubernetesEventTypes = async() =>{
         try{
@@ -1277,26 +1369,19 @@ export const AlertRule = ({ type }) => {
                                         </MyFormItem>
 
                                         <div style={{ display: 'flex', alignItems: 'center', gap: '12px', marginBottom: '12px' }}>
-                                            <span style={{ fontWeight: 500 }}>节点阈值覆盖</span>
+                                            <span style={{ fontWeight: 500 }}>标签阈值覆盖</span>
                                             <Switch
                                                 checked={thresholdMode === THRESHOLD_MODE_NODE_OVERRIDE}
                                                 onChange={(checked) => {
                                                     form.setFieldsValue({
                                                         prometheusConfig: {
                                                             thresholdMode: checked ? THRESHOLD_MODE_NODE_OVERRIDE : THRESHOLD_MODE_GLOBAL,
-                                                            thresholdOverrides: checked ? form.getFieldValue(['prometheusConfig', 'thresholdOverrides']) || [] : [],
                                                         },
                                                     })
                                                 }}
                                             />
-                                            {thresholdMode === THRESHOLD_MODE_NODE_OVERRIDE && (
-                                                <Button
-                                                    size="small"
-                                                    loading={loadingNodeInstances}
-                                                    onClick={handleQueryNodeInstances}
-                                                >
-                                                    查询节点
-                                                </Button>
+                                            {thresholdMode === THRESHOLD_MODE_NODE_OVERRIDE && loadingMetricLabels && (
+                                                <Typography.Text type="secondary">标签加载中...</Typography.Text>
                                             )}
                                         </div>
 
@@ -1309,24 +1394,47 @@ export const AlertRule = ({ type }) => {
                                                                 key={key}
                                                                 style={{
                                                                     display: 'grid',
-                                                                    gridTemplateColumns: 'minmax(220px, 1.5fr) 120px minmax(180px, 1fr) 180px 48px',
+                                                                    gridTemplateColumns: 'minmax(160px, 0.9fr) minmax(220px, 1.3fr) 120px minmax(180px, 1fr) 180px 48px',
                                                                     gap: '10px',
                                                                     alignItems: 'start',
                                                                     marginBottom: '8px',
                                                                 }}
                                                             >
                                                                 <Form.Item
-                                                                    {...restField}
-                                                                    name={[name, 'matchLabels', 'instance']}
-                                                                    rules={[{ required: true, message: '请输入节点 instance' }]}
+                                                                    required
                                                                 >
                                                                     <AutoComplete
-                                                                        placeholder="选择或输入节点 instance"
-                                                                        options={nodeInstanceOptions}
+                                                                        value={getOverrideMatchLabelKey(name)}
+                                                                        placeholder="标签名，例如 instance"
+                                                                        options={metricLabelOptions}
+                                                                        onChange={(value) => updateOverrideMatchLabelKey(name, value)}
                                                                         filterOption={(inputValue, option) =>
                                                                             option?.value?.toUpperCase().includes(inputValue.toUpperCase())
                                                                         }
                                                                     />
+                                                                </Form.Item>
+
+                                                                <Form.Item
+                                                                    {...restField}
+                                                                    shouldUpdate
+                                                                >
+                                                                    {() => {
+                                                                        const labelKey = getOverrideMatchLabelKey(name)
+                                                                        const labelValue = form.getFieldValue(['prometheusConfig', 'thresholdOverrides', name, 'matchLabels', labelKey]) || ''
+
+                                                                        return (
+                                                                            <AutoComplete
+                                                                                value={labelValue}
+                                                                                placeholder={labelKey ? "标签值，例如 10.0.0.1:9100" : "请先选择标签名"}
+                                                                                options={metricLabelValueOptions[labelKey] || []}
+                                                                                onChange={(value) => updateOverrideMatchLabelValue(name, labelKey, value)}
+                                                                                disabled={!labelKey}
+                                                                                filterOption={(inputValue, option) =>
+                                                                                    option?.value?.toUpperCase().includes(inputValue.toUpperCase())
+                                                                                }
+                                                                            />
+                                                                        )
+                                                                    }}
                                                                 </Form.Item>
 
                                                                 <Form.Item
@@ -1384,7 +1492,7 @@ export const AlertRule = ({ type }) => {
                                                             block
                                                             icon={<PlusOutlined />}
                                                             onClick={() => add({
-                                                                matchLabels: { instance: '' },
+                                                                matchLabels: {},
                                                                 rules: [{
                                                                     severity: getDefaultOverrideSeverity(),
                                                                     expr: '',
@@ -1392,7 +1500,7 @@ export const AlertRule = ({ type }) => {
                                                                 }],
                                                             })}
                                                         >
-                                                            添加节点阈值
+                                                            添加标签阈值
                                                         </Button>
                                                     </>
                                                 )}


### PR DESCRIPTION
### 变更说明

本 PR 为 Prometheus 告警规则页面增加标签阈值覆盖配置能力。

用户可以在规则配置页面开启“标签阈值覆盖”，然后基于当前 PromQL 返回的指标标签，为不同标签值配置不同的告警阈值、等级和持续时间。

### 主要改动

- 增加“标签阈值覆盖”开关
- 支持选择或手动输入标签名和标签值
- 根据当前 PromQL 查询结果自动加载可用标签 key/value
- 支持按标签配置独立的 `severity`、`expr`、`forDuration`
- 关闭开关时保留已填写的覆盖记录，避免误操作丢失

### 使用方式

1. 选择 Prometheus 数据源
2. 填写 PromQL
3. 开启“标签阈值覆盖”
4. 页面会自动从当前 PromQL 查询结果中加载标签
5. 添加标签阈值覆盖项
6. 选择标签名、标签值，并配置独立阈值

### 关联 Issue
Refs opsre/WatchAlert#248

### 后端 PR
依赖后端 PR：opsre/WatchAlert#249
