### PR TITLE
支持 SSL 拨测域名自定义端口

### DIFF
--- a/src/pages/probing/create.jsx
+++ b/src/pages/probing/create.jsx
@@ -30,7 +30,16 @@ const VALIDATION_PATTERNS = {
     url: /^https?:\/\/.+/,
     domainIp: /^([a-zA-Z0-9.-]+|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/,
     tcp: /^([a-zA-Z0-9.-]+|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}):\d+$/,
-    domain: /^[a-zA-Z0-9.-]+$/
+    domain: /^([a-zA-Z0-9.-]+)(?::(\d+))?$/
+}
+
+const isValidPort = (port) => {
+    if (!port) {
+        return true
+    }
+
+    const portNumber = Number.parseInt(port, 10)
+    return portNumber >= 1 && portNumber <= 65535
 }
 
 const PROTOCOL_OPTIONS = [
@@ -143,8 +152,9 @@ export const CreateProbingRule = ({ type }) => {
                     }
                     break
                 case "SSL":
-                    if (!VALIDATION_PATTERNS.domain.test(endpoint)) {
-                        return Promise.reject("请输入有效的域名，例如：github.com")
+                    const match = VALIDATION_PATTERNS.domain.exec(endpoint)
+                    if (!match || !isValidPort(match[2])) {
+                        return Promise.reject("请输入有效的域名，例如：github.com 或 github.com:443")
                     }
                     break
                 default:
@@ -513,7 +523,7 @@ export const CreateProbingRule = ({ type }) => {
                             <Input
                                 placeholder={protocolType === "ICMP" 
                                     ? "请输入端点，多个端点请用英文逗号分隔，例如：github.com,8.8.8.8"
-                                    : "请输入端点，多个端点请用英文逗号分隔，例如：github.com,example.com"
+                                    : "请输入端点，多个端点请用英文逗号分隔，例如：github.com,example.com:443"
                                 }
                             />
                         )}

--- a/src/pages/probing/once.jsx
+++ b/src/pages/probing/once.jsx
@@ -10,6 +10,15 @@ import { Breadcrumb } from "../../components/Breadcrumb";
 
 const { Panel } = Collapse
 
+const isValidPort = (port) => {
+    if (!port) {
+        return true
+    }
+
+    const portNumber = Number.parseInt(port, 10)
+    return portNumber >= 1 && portNumber <= 65535
+}
+
 // Context for managing nested form item names
 const MyFormItemContext = React.createContext([])
 
@@ -68,7 +77,7 @@ export const OnceProbing = () => {
         const urlPattern = /^(https?:\/\/)[a-zA-Z0-9.-]+(?::\d+)?(?:\/[^\s]*)?$/
         const domainIpPattern = /^(([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}|(\d{1,3}\.){3}\d{1,3})$/
         const tcpPattern = /^(([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}|(\d{1,3}\.){3}\d{1,3}):\d+$/
-        const domainPattern = /^([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$/
+        const domainPattern = /^([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(?::(\d+))?$/
 
         if (!value) {
             return Promise.reject("请输入端点")
@@ -88,9 +97,10 @@ export const OnceProbing = () => {
                     ? Promise.resolve()
                     : Promise.reject("请输入有效的 IP/域名:port")
             case "SSL":
-                return domainPattern.test(value)
+                const match = domainPattern.exec(value)
+                return match && isValidPort(match[2])
                     ? Promise.resolve()
-                    : Promise.reject("请输入有效的 域名")
+                    : Promise.reject("请输入有效的 域名或域名:端口")
             default:
                 return Promise.resolve()
         }
@@ -432,7 +442,7 @@ export const OnceProbing = () => {
         HTTP: "请输入端点，如：https://github.com",
         ICMP: "请输入端点，如：127.0.0.1 / github.com",
         TCP: "请输入端点，如：127.0.0.1:80",
-        SSL: "请输入端点，如：github.com",
+        SSL: "请输入端点，如：github.com 或 github.com:443",
     }
 
     return (


### PR DESCRIPTION
## 变更内容

- 支持 SSL 即时拨测输入带自定义端口的域名，例如 `github.com:443`
- 支持 SSL 拨测规则创建/编辑时配置带自定义端口的域名
- 增加 SSL 域名端口范围校验，仅允许 `1-65535`

## 验证

- `github.com` 校验通过
- `github.com:1`、`github.com:443`、`github.com:65535` 校验通过
- `github.com:0`、`github.com:65536`、`github.com:`、`github.com:abc` 校验不通过
- `https://github.com` 仍不符合 SSL 域名输入格式